### PR TITLE
Fix: RTL indentation in preview/edit mode and when exporting to PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download available through Community plugins in Obsidian settings
 A new standalone listener, **`VHeadingLevelIndentListener`**, has been introduced to monitor changes to the `vheadinglevelindent` frontmatter field.
 
 * Listens for metadata changes in the active file
-* Enables or disables heading indent in real time，Heading indent can be toggled using the frontmatter property: vheadinglevelindent. Setting vheadinglevelindent: 1 enables indent, while omitting the property or setting it to 0 disables it.
+* Enables or disables heading indent in real time，Heading indent can be toggled using the frontmatter property: vheadinglevelindent. Omitting the property or setting vheadinglevelindent: 1 enables indent, while setting it to 0 disables it.
 * Triggers a preview re-render when the value changes
 * Enable heading indent by default unless vheadinglevelindent is set to 0, If the vheadinglevelindent option is not set, indent will still be applied. Numbering is disabled only when vheadinglevelindent is explicitly set to 0.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Download available through Community plugins in Obsidian settings
   - [x] image embed
   - [x] excalidraw embed
   - [x] canvas embed
-- [ ] indentation in pdf export https://github.com/svonjoi/obsidian-heading-level-indent/issues/6
+- [X] indentation in pdf export https://github.com/svonjoi/obsidian-heading-level-indent/issues/6
 - [ ] indentation within callouts https://github.com/svonjoi/obsidian-heading-level-indent/issues/5
 - [ ] indentation within canvas
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Download available through Community plugins in Obsidian settings
 - [ ] indentation within callouts https://github.com/svonjoi/obsidian-heading-level-indent/issues/5
 - [ ] indentation within canvas
 
+## About This Folk
+
+### 🐞 Bug Fix: No indentation in PDF export
+
+
+### ✨ New Feature: Frontmatter-based heading indent toggle
+
+A new standalone listener, **`VHeadingLevelIndentListener`**, has been introduced to monitor changes to the `vheadinglevelindent` frontmatter field.
+
+* Listens for metadata changes in the active file
+* Enables or disables heading indent in real time，Heading indent can be toggled using the frontmatter property: vheadinglevelindent. Setting vheadinglevelindent: 1 enables indent, while omitting the property or setting it to 0 disables it.
+* Triggers a preview re-render when the value changes
+* Enable heading indent by default unless vheadinglevelindent is set to 0, If the vheadinglevelindent option is not set, indent will still be applied. Numbering is disabled only when vheadinglevelindent is explicitly set to 0.
+
+This allows users to control heading indent **per document**, without reloading or reopening the file.
+
 ## Contributors
 
 <a href="https://github.com/svonjoi/obsidian-heading-level-indent/graphs/contributors">

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download available through Community plugins in Obsidian settings
 A new standalone listener, **`VHeadingLevelIndentListener`**, has been introduced to monitor changes to the `vheadinglevelindent` frontmatter field.
 
 * Listens for metadata changes in the active file
-* Enables or disables heading indent in real time，Heading indent can be toggled using the frontmatter property: vheadinglevelindent. Omitting the property or setting vheadinglevelindent: 1 enables indent, while setting it to 0 disables it.
+* Enables or disables heading indent in real time，Heading indent can be toggled using the frontmatter property: vheadinglevelindent. Omitting the property or setting vheadinglevelindent to 1 enables indent, while setting it to 0 disables it.
 * Triggers a preview re-render when the value changes
 * Enable heading indent by default unless vheadinglevelindent is set to 0, If the vheadinglevelindent option is not set, indent will still be applied. Numbering is disabled only when vheadinglevelindent is explicitly set to 0.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "heading-level-indent",
 	"name": "Heading Level Indent",
-	"version": "2.1.1",
+	"version": "2.1.3",
 	"minAppVersion": "0.12.0",
 	"description": "Indenting content under headers based on their level",
 	"author": "svonjoi",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,14 +40,12 @@
 		"node_modules/@codemirror/state": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-			"integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==",
-			"peer": true
+			"integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
 		},
 		"node_modules/@codemirror/view": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.1.tgz",
 			"integrity": "sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.1.4",
 				"style-mod": "^4.0.0",
@@ -80,6 +78,7 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
 			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -102,6 +101,7 @@
 			"version": "8.57.0",
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
 			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -110,6 +110,7 @@
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
 			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.2",
 				"debug": "^4.3.1",
@@ -123,6 +124,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -134,7 +136,8 @@
 		"node_modules/@humanwhocodes/object-schema": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"peer": true
 		},
 		"node_modules/@lezer/common": {
 			"version": "1.0.2",
@@ -284,7 +287,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.16.0.tgz",
 			"integrity": "sha512-fkDq86F0zl8FicnJtdXakFs4lnuebH6ZADDw6CYQv0UZeIjHvmEw87m9/29nk2Dv5Lmdp0zQ3zDQhiMWQf/GbA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.16.0",
 				"@typescript-eslint/types": "5.16.0",
@@ -476,7 +478,8 @@
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"peer": true
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -494,6 +497,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -502,6 +506,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -517,6 +522,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -525,6 +531,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -538,7 +545,8 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"peer": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -557,6 +565,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -589,6 +598,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -597,6 +607,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -612,6 +623,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -622,17 +634,20 @@
 		"node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"peer": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -661,7 +676,8 @@
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"peer": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -678,6 +694,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -939,6 +956,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1056,6 +1074,7 @@
 			"version": "7.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1071,6 +1090,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1079,6 +1099,7 @@
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -1095,6 +1116,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1106,6 +1128,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1142,6 +1165,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1149,7 +1173,8 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.11",
@@ -1180,12 +1205,14 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -1199,6 +1226,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -1221,6 +1249,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1236,6 +1265,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -1248,12 +1278,14 @@
 		"node_modules/flatted": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"peer": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"peer": true
 		},
 		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
@@ -1265,6 +1297,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1284,6 +1317,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1295,6 +1329,7 @@
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
 			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -1333,6 +1368,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1349,6 +1385,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -1364,6 +1401,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -1372,6 +1410,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1380,7 +1419,8 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"peer": true
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -1413,6 +1453,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1420,12 +1461,14 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"peer": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1436,22 +1479,26 @@
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"peer": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -1460,6 +1507,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -1472,6 +1520,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -1485,7 +1534,8 @@
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"peer": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -1511,6 +1561,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1555,6 +1606,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -1563,6 +1615,7 @@
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -1579,6 +1632,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -1593,6 +1647,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -1607,6 +1662,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -1618,6 +1674,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1626,6 +1683,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1634,6 +1692,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1661,6 +1720,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -1669,6 +1729,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1708,6 +1769,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -1725,6 +1787,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -1772,6 +1835,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -1783,6 +1847,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1799,6 +1864,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -1810,6 +1876,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -1826,6 +1893,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -1836,7 +1904,8 @@
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"peer": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -1870,6 +1939,7 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -1881,6 +1951,7 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1892,7 +1963,6 @@
 			"version": "4.4.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
 			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -1962,7 +2032,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.9.0.tgz",
 			"integrity": "sha512-qHMJfkL5qvgQB2aLvhUSXxbK7OLnDkwPzFalg458pxQgfxKDfT1ZDbHQM/I6mDIf/svlMkj21kzKuQ2ixJlatQ==",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "7.9.0",
 				"@typescript-eslint/types": "7.9.0",
@@ -2130,6 +2199,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -2143,6 +2213,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -2157,6 +2228,7 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2164,12 +2236,14 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"peer": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/src/VHeadingLevelIndentListener.ts
+++ b/src/VHeadingLevelIndentListener.ts
@@ -1,0 +1,151 @@
+import { App, TFile } from "obsidian";
+
+/**
+ * Listener for frontmatter field `vheadinglevelindent`
+ * Detects value changes on the active file and notifies subscribers.
+ */
+export class VHeadingLevelIndentListener {
+  private app: App;
+
+  public currentVHeadingLevelIndent: string | null = null;
+  private currentFile: TFile | null = null;
+
+  private listeners: Array<
+    (
+      newValue: string | null,
+      oldValue: string | null,
+      newFile: TFile | null,
+      oldFile: TFile | null
+    ) => void
+  > = [];
+
+  public fileChanged = false;
+  public valueChanged = false;
+
+  constructor(app: App) {
+    this.app = app;
+  }
+
+  /**
+   * Update current value and detect whether `vheadinglevelindent` has changed
+   */
+  update(): string | null {
+    const prevVHeadingLevelIndent = this.currentVHeadingLevelIndent;
+    const prevFile = this.currentFile;
+
+    const currentFile = this.app.workspace.getActiveFile();
+    this.currentFile = currentFile;
+
+    if (currentFile) {
+      const metadata = this.app.metadataCache.getFileCache(currentFile);
+      const frontmatter = metadata?.frontmatter;
+
+      this.currentVHeadingLevelIndent =
+        frontmatter?.vheadinglevelindent !== undefined
+          ? String(frontmatter.vheadinglevelindent)
+          : null;
+    } else {
+      this.currentVHeadingLevelIndent = null;
+    }
+
+    // Check whether file or value has changed
+    this.fileChanged = prevFile !== currentFile;
+    this.valueChanged = this.currentVHeadingLevelIndent !== prevVHeadingLevelIndent;
+
+    // Notify listeners only when value changes
+    // if (this.fileChanged || this.valueChanged) {
+    if (this.valueChanged) {
+      this.notifyListeners(
+        this.currentVHeadingLevelIndent,
+        prevVHeadingLevelIndent,
+        currentFile,
+        prevFile
+      );
+    }
+
+    return this.currentVHeadingLevelIndent;
+  }
+
+  /**
+   * Add a listener callback
+   */
+  addListener(
+    callback: (
+      newValue: string | null,
+      oldValue: string | null,
+      newFile: TFile | null,
+      oldFile: TFile | null
+    ) => void
+  ): void {
+    this.listeners.push(callback);
+  }
+
+  /**
+   * Remove a listener callback
+   */
+  removeListener(
+    callback: (
+      newValue: string | null,
+      oldValue: string | null,
+      newFile: TFile | null,
+      oldFile: TFile | null
+    ) => void
+  ): void {
+    const index = this.listeners.indexOf(callback);
+    if (index > -1) {
+      this.listeners.splice(index, 1);
+    }
+  }
+
+  /**
+   * Notify all registered listeners
+   */
+  private notifyListeners(
+    newValue: string | null,
+    oldValue: string | null,
+    newFile: TFile | null,
+    oldFile: TFile | null
+  ): void {
+    this.listeners.forEach((listener) => {
+      try {
+        listener(newValue, oldValue, newFile, oldFile);
+      } catch (error) {
+        console.error("Listener execution error:", error);
+      }
+    });
+  }
+
+  /**
+   * Start listening to workspace and metadata changes
+   */
+  start(): void {
+    // Listen for active file changes
+    this.app.workspace.on("active-leaf-change", () => {
+      this.update();
+    });
+
+    // Listen for metadata changes
+    this.app.metadataCache.on("changed", (file: TFile) => {
+      const activeFile = this.app.workspace.getActiveFile();
+      if (activeFile && activeFile.path === file.path) {
+        this.update();
+      }
+    });
+
+    // Initial update
+    this.update();
+  }
+}
+
+let _listener: VHeadingLevelIndentListener | null = null;
+
+export function initVHeadingLevelIndentListener(app: App) {
+  _listener = new VHeadingLevelIndentListener(app);
+}
+
+export function getVHeadingLevelIndentListener(): VHeadingLevelIndentListener {
+  if (!_listener) {
+    throw new Error("VHeadingLevelIndentListener not initialized");
+  }
+  return _listener;
+}

--- a/src/editingMode.ts
+++ b/src/editingMode.ts
@@ -20,6 +20,10 @@ import {
 	ViewPlugin,
 	ViewUpdate
 } from "@codemirror/view";
+import {
+	initVHeadingLevelIndentListener, 
+	getVHeadingLevelIndentListener
+} from "./VHeadingLevelIndentListener";
 
 /**
  * indentStateField stored value.
@@ -79,6 +83,8 @@ function syntaxTreeChanged(tr: Transaction): boolean {
 }
 
 function getDecorationSet(state: EditorState): DecorationSetWithIntervals {
+	if (getVHeadingLevelIndentListener().currentVHeadingLevelIndent == "0") 
+		return { decorations: Decoration.none, intervals: [] };
 	/**
 	 * scan headings across document
 	 */

--- a/src/editingMode.ts
+++ b/src/editingMode.ts
@@ -146,12 +146,12 @@ function getDecorationSet(state: EditorState): DecorationSetWithIntervals {
 
 		intervals.push([headingPos, pxForDataLine]);
 		const dataStyles =
-			`left:${pxForDataLine}px;` +
+			`inset-inline-start:${pxForDataLine}px;` +
 			// we indent on the left side, so we need to reduce the width of the line also
 			`width:${containerWidth - pxForDataLine}px;`;
 
 		const headingStyles =
-			`left:${pxForHeadingLine}px;` + `width:${containerWidth - pxForHeadingLine}px;`;
+			`inset-inline-start:${pxForHeadingLine}px;` + `width:${containerWidth - pxForHeadingLine}px;`;
 
 		builder.add(
 			headingLine.from,
@@ -235,7 +235,7 @@ export const indentEmbedsPlugin = ViewPlugin.fromClass(
 							prevIntervalIndex
 						);
 						prevIntervalIndex = intervalIndex;
-						embed.style.left = `${offset}px`;
+						embed.style.insetInlineStart = `${offset}px`;
 						embed.style.width = `${containerWidth - offset}px`;
 					}
 
@@ -253,7 +253,7 @@ export const indentEmbedsPlugin = ViewPlugin.fromClass(
 						);
 						prevIntervalIndex = intervalIndex;
 						embed.style.position = "relative";
-						embed.style.left = `${offset}px`;
+						embed.style.insetInlineStart = `${offset}px`;
 						embed.style.width = `${containerWidth - offset}px`;
 					}
 
@@ -271,7 +271,7 @@ export const indentEmbedsPlugin = ViewPlugin.fromClass(
 						);
 						prevIntervalIndex = intervalIndex;
 						img.style.position = "relative";
-						img.style.left = `${offset}px`;
+						img.style.insetInlineStart = `${offset}px`;
 						img.style.maxWidth = `${containerWidth - offset}px`;
 					}
 				}

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,17 +137,23 @@ export default class HeadingIndent extends Plugin {
 
 		const divsArray = Array.from(divs);
 		// Iterate through all elements
-		for (const element of divsArray) {
-			const tagName = element.tagName.toLowerCase();
+		for (const element2 of divsArray) {
+			// Skip inline title, which is also h1
+			if (element.closest('.print') !== null && element2.classList.contains('__title__')) {
+			  console.log('PDF export: Skip inline title, dont number its heading');
+			  continue;
+			}
+			
+			const tagName = element2.tagName.toLowerCase();
 
 			// If it's a heading
 			if (tagName.match(/^h[1-6]$/)) {
 				const level = parseInt(tagName.charAt(1));
 				currentHeadingLevel = level;
-				lastHeadingElement = element as HTMLElement;
+				lastHeadingElement = element2 as HTMLElement;
 
 				// Set the heading's indentation (using the previous heading level's indentation value)
-				const parentDiv = element.parentElement;
+				const parentDiv = element2.parentElement;
 				if (parentDiv && parentDiv.tagName === 'DIV') {
 					const indent = (settings as any)[`h${level - 1}`] || 0;
 					parentDiv.style.paddingLeft = `${indent}px`;
@@ -157,7 +163,7 @@ export default class HeadingIndent extends Plugin {
 			// If it's a content element
 			else if (currentHeadingLevel > 0) {
 				// Find the div containing this content
-				const parentDiv = element.parentElement;
+				const parentDiv = element2.parentElement;
 				if (parentDiv && parentDiv.tagName === 'DIV' && parentDiv !== lastHeadingElement?.parentElement) {
 					const indent = (settings as any)[`h${currentHeadingLevel}`] || 0;
 					parentDiv.style.paddingLeft = `${indent}px`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -161,14 +161,19 @@ export default class HeadingIndent extends Plugin {
 	
 	// New method: Apply indentation to Markdown elements
 	applyIndentToMarkdown(element: HTMLElement) {
+		const isPrint = element.closest(".print") !== null;
 		if (getVHeadingLevelIndentListener().currentVHeadingLevelIndent === "0")
 			return;
 
 		// Run only once on the root container to avoid duplicate processing
-		if (!element.classList.contains('markdown-preview-view')) {
-			return;
+		if (
+    		!element.classList.contains("markdown-preview-view") &&
+			!element.classList.contains("markdown-rendered") &&
+			!element.classList.contains("print")
+		) {
+    		return;
 		}
-
+		
 		const settings = this.settings;
 		const divs = element.querySelectorAll('div > h1, div > h2, div > h3, div > h4, div > h5, div > h6, div > p, div > ul, div > ol, div > blockquote, div > table');
 
@@ -179,7 +184,7 @@ export default class HeadingIndent extends Plugin {
 		// Iterate through all elements
 		for (const element2 of divsArray) {
 			// Skip inline title, which is also h1
-			if (element.closest('.print') !== null && element2.classList.contains('__title__')) {
+			if (element.closest(".print") && element2.classList.contains("__title__")) {
 			  console.log('PDF export: Skip inline title, dont number its heading');
 			  continue;
 			}
@@ -196,7 +201,13 @@ export default class HeadingIndent extends Plugin {
 				const parentDiv = element2.parentElement;
 				if (parentDiv && parentDiv.tagName === 'DIV') {
 					const indent = (settings as any)[`h${level - 1}`] || 0;
-					parentDiv.style.paddingLeft = `${indent}px`;
+					const text = element2.textContent || "";
+					const isRTL = /[\u0591-\u07FF]/.test(text);
+					if (isRTL) {
+						parentDiv.style.paddingRight = `${indent}px`;
+					} else {
+						parentDiv.style.paddingLeft = `${indent}px`;
+					}
 					parentDiv.classList.add(`heading_h${level}`);
 				}
 			}
@@ -206,7 +217,13 @@ export default class HeadingIndent extends Plugin {
 				const parentDiv = element2.parentElement;
 				if (parentDiv && parentDiv.tagName === 'DIV' && parentDiv !== lastHeadingElement?.parentElement) {
 					const indent = (settings as any)[`h${currentHeadingLevel}`] || 0;
-					parentDiv.style.paddingLeft = `${indent}px`;
+					const text = element2.textContent || "";
+					const isRTL = /[\u0591-\u07FF]/.test(text);
+					if (isRTL) {
+						parentDiv.style.paddingRight = `${indent}px`;
+					} else {
+						parentDiv.style.paddingLeft = `${indent}px`;
+					}
 					parentDiv.classList.add(`data_h${currentHeadingLevel}`);
 				}
 			}

--- a/src/readingMode.ts
+++ b/src/readingMode.ts
@@ -200,6 +200,16 @@ export class ShitIndenting {
 			});
 		}
 	}
+	clearCurrentView() {
+		const container = activeDocument.querySelector<HTMLElement>(this.containerSelector);
+		if (!container) 
+			return;
+		const divs = Array.from(container.children) as HTMLElement[];
+		this.cleanSectionModifications(divs); // 复用已有的清理方法
+	}
+	applyToCurrentView(plugin : HeadingIndent) {
+		this.applyIndentation(plugin); // 直接对当前视图应用缩进
+	}
 }
 
 /*

--- a/src/readingMode.ts
+++ b/src/readingMode.ts
@@ -135,6 +135,7 @@ export class ShitIndenting {
 	 * the plugin settings
 	 */
 	private applyIndentation(plugin: HeadingIndent) {
+		console.log("applyIndentation running");
 		const settings = plugin.settings;
 
 		const divsNodeList = activeDocument.querySelectorAll<HTMLElement>(
@@ -163,22 +164,33 @@ export class ShitIndenting {
 
 		let hNumber = 0;
 
+		const container = activeDocument.querySelector(this.containerSelector) as HTMLElement;
+		const isRTL = container && getComputedStyle(container).direction === "rtl";
+
 		suck: for (const div of arrDivs) {
 			// skip excluded divs
 			if (excludedClassNames.some((className) => div.classList.contains(className))) {
 				continue suck;
 			}
 
-			const headingNodeList = div.querySelectorAll("h1, h2, h3, h4, h5, h6"),
-				currentDivIsHeading = headingNodeList.length > 0;
+			const headingElement = div.querySelector("h1, h2, h3, h4, h5, h6");
+			const currentDivIsHeading = !!headingElement;
 
 			if (currentDivIsHeading) {
-				const hTag: string = headingNodeList[0].tagName.toLowerCase();
+				const hTag: string = headingElement.tagName.toLowerCase();
 				hNumber = parseInt(hTag.replace(/^\D+/g, "")); // h5 -> 5, h1 -> 1, etc.
-				div.style.paddingLeft = arrMargins[hNumber - 1] + "px";
+				const indent = arrMargins[hNumber - 1];
+				const element = div.firstElementChild as HTMLElement;
+				if (element) {
+					element.style.paddingInlineStart = indent + "px";
+				}
 				div.classList.add(this.arrClassesHeadings[hNumber]);
 			} else {
-				div.style.paddingLeft = arrMargins[hNumber] + "px";
+				const indent = arrMargins[hNumber];
+				const element = div.firstElementChild as HTMLElement;
+				if (element) {
+					element.style.paddingInlineStart = indent + "px";
+				}
 				div.classList.add(this.arrClassesData[hNumber]);
 			}
 		}
@@ -191,7 +203,7 @@ export class ShitIndenting {
 	private cleanSectionModifications(arrDivs: HTMLElement[]) {
 		for (const div of arrDivs) {
 			// div.classList.remove("undefined");
-			div.style.paddingLeft = null;
+			div.style.paddingInlineStart = null;
 
 			div.classList.forEach((item: string) => {
 				if (item.startsWith("data_") || item.startsWith("heading_")) {


### PR DESCRIPTION
This PR fixes two issues related to RTL indentation.

Changes:

Fix RTL indentation in both preview and edit modes
Ensure heading indentation is preserved when exporting notes to PDF
Closes https://github.com/svonjoi/obsidian-heading-level-indent/issues/34